### PR TITLE
Add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@tippyjs/react": "^4.2.0",
     "@web3-react/core": "^6.1.1",
     "bcoin": "git+https://github.com/bcoin-org/bcoin.git",
+    "bcrypto": "^5.4.0",
     "classnames": "^2.2.6",
     "electrum-client-js": "git+https://github.com/keep-network/electrum-client-js.git#v0.1.0",
     "emotion": "^10.0.27",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4621,6 +4621,14 @@ bcrypt-pbkdf@^1.0.0:
   dependencies:
     tweetnacl "^0.14.3"
 
+bcrypto@^5.4.0:
+  version "5.4.0"
+  resolved "https://registry.yarnpkg.com/bcrypto/-/bcrypto-5.4.0.tgz#4046f0c44a4b301eff84de593b4f86fce8d91db2"
+  integrity sha512-KDX2CR29o6ZoqpQndcCxFZAtYA1jDMnXU3jmCfzP44g++Cu7AHHtZN/JbrN/MXAg9SLvtQ8XISG+eVD9zH1+Jg==
+  dependencies:
+    bufio "~1.0.7"
+    loady "~0.0.5"
+
 "bcrypto@git+https://github.com/bcoin-org/bcrypto.git#semver:~5.0.3", "bcrypto@git+https://github.com/bcoin-org/bcrypto.git#semver:~5.0.4":
   version "5.0.4"
   resolved "git+https://github.com/bcoin-org/bcrypto.git#0a01f693443d8b19f6db1154e0133c7bf703b205"
@@ -5092,7 +5100,7 @@ bufferutil@^4.0.1:
   dependencies:
     node-gyp-build "~3.7.0"
 
-"bufio@git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6", bufio@~1.0.6:
+"bufio@git+https://github.com/bcoin-org/bufio.git#semver:~1.0.6", bufio@~1.0.6, bufio@~1.0.7:
   version "1.0.7"
   resolved "git+https://github.com/bcoin-org/bufio.git#91ae6c93899ff9fad7d7cee9afd2a1c4933ca984"
 
@@ -10622,7 +10630,7 @@ loader-utils@^1.1.0, loader-utils@^1.2.3, loader-utils@^1.4.0:
     emojis-list "^3.0.0"
     json5 "^1.0.1"
 
-"loady@git+https://github.com/chjj/loady.git#semver:~0.0.1", loady@~0.0.1:
+"loady@git+https://github.com/chjj/loady.git#semver:~0.0.1", loady@~0.0.1, loady@~0.0.5:
   version "0.0.5"
   resolved "git+https://github.com/chjj/loady.git#b94958b7ee061518f4b85ea6da380e7ee93222d5"
 


### PR DESCRIPTION
Right now, after installing the dependencies with and starting the dev server with `yarn start` I get the following error:
```
./src/utils/BitcoinHelpers.js
Module not found: Can't resolve 'bcrypto/lib/secp256k1-browser.js' in '/home/corollari/projects/allthekeeps/src/utils'
```

This PR fixes this by adding the missing package.