### PR TITLE
Fix type error and add CI

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,17 @@
+name: Frontend
+
+on: [ push, pull_request ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Get Node.js
+      uses: actions/setup-node@v1
+      with:
+        node-version: 12
+    - run: npm i
+    - run: npm run build
+      env:
+        CI: false

--- a/src/TimeTravel.tsx
+++ b/src/TimeTravel.tsx
@@ -95,7 +95,7 @@ export function useQueryWithTimeTravel<TData = any, TVariables = OperationVariab
     variables: {
       ...options?.variables,
       block: block ? {number: block} : undefined
-    } as TVariables
+    } as unknown as TVariables
   });
 }
 


### PR DESCRIPTION
When building a fork that used the pending subgraph I ran into a type error, this PR fixes that and adds a CI job that attempts to build the project (in order to catch this type of errors in the future).